### PR TITLE
Catch exception

### DIFF
--- a/src/android/notification/Options.java
+++ b/src/android/notification/Options.java
@@ -658,9 +658,12 @@ public final class Options {
         if (tag == null)
             return null;
 
-        MediaSessionCompat session = new MediaSessionCompat(context, tag);
-
-        return session.getSessionToken();
+        try {
+            MediaSessionCompat session = new MediaSessionCompat(context, tag);
+            return session.getSessionToken();
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
Fatal Exception: java.lang.RuntimeException
Can't create handler inside thread that has not called Looper.prepare()